### PR TITLE
Allow custom appPath

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,7 @@
     no-unused-vars:
       - 1
       - args: none
-    no-comma-dangle: 1
+    comma-dangle: 1
     eqeqeq: 2
     dot-notation: 1
 

--- a/lib/loke-config.js
+++ b/lib/loke-config.js
@@ -8,14 +8,22 @@ var objLock = require('./obj-lock');
 
 /**
  * Creates a new LOKE config instance
- * @param {String} appName The application name or ID. 
+ * @param {String} appName The application name or ID.
  *                         Should match where the config files are placed/
- * @param {[type]} [paths] An array of full paths to search for files. 
- *                         The first file on the list should be the defaults and specify all values.
+ * @param {String} [options.appPath]
+ * @param {[String]} [options.paths] An array of full paths to search for files.
+ *                           The first file on the list should be the defaults and specify all values.
  */
-function LokeConfig(appName, paths) {
-  var path, settings, self = this;
-  paths = paths || self._getDefaultPaths(appName);
+function LokeConfig(appName, options) {
+  options = options || {};
+  if (Array.isArray(options)) {
+    // Support original argument format:
+    options = {paths: options};
+  }
+
+  var settings, self = this;
+  var appPath = options.appPath || path.dirname(require.main.filename);
+  var paths = options.paths || self._getDefaultPaths(appName, appPath);
 
   // check args
 
@@ -31,31 +39,28 @@ function LokeConfig(appName, paths) {
 
   // first load defaults...
   // the defaults file locks the object model, so all settings must be defined here.
-  // 
+  //
   // anything not defined here won't be able to be set.
   // this forces everyone to keep the defaults file up to date, and in essence becomes
   // the documentation for our settings
-  // 
+  //
   // the defaults file should always be the first path
-  
+
   if (!fs.existsSync(paths[0])) {
     throw new Error('Default file missing. Expected path is: ' + paths[0]);
   }
-  
+
   settings = self._loadYamlFile(paths[0]) || {};
 
   // prevent extensions stops any properties not specified in the defaults file
   // from being added... thus ALL settings must be defined in defaults
   objLock.lockModel(settings);
 
-  for (var i = 1; i < paths.length; i++) {
-    path = paths[i];
-    paths.forEach(function(path) {
-      if (fs.existsSync(path)) {
-        settings = mergeInto(settings, self._loadYamlFile(path));
-      }
-    });
-  }
+  paths.slice(1).forEach(function(path) {
+    if (fs.existsSync(path)) {
+      settings = mergeInto(settings, self._loadYamlFile(path));
+    }
+  });
 
   // configuration values will now be locked
   objLock.lockValues(settings);
@@ -91,13 +96,12 @@ LokeConfig.prototype.get = function (key) {
   }
 };
 
-LokeConfig.prototype._getDefaultPaths = function(appName) {
-  var appPath = path.dirname(require.main.filename);
+LokeConfig.prototype._getDefaultPaths = function(appName, appPath) {
   return [
     path.join(appPath, '/config/defaults.yml'),
     '/etc/'+appName+'/config.yml',
     '/private/etc/'+appName+'/config.yml',
-    path.join(appPath, '/config/config.yml'),
+    path.join(appPath, '/config/config.yml')
   ];
 };
 

--- a/package.json
+++ b/package.json
@@ -7,15 +7,24 @@
     "lint": "eslint --rulesdir eslint-rules .",
     "test": "mocha test"
   },
-  "repository": {
-    "type": "git"
-  },
   "author": "",
   "dependencies": {
     "js-yaml": "^3.2.7"
   },
   "devDependencies": {
-    "eslint": "^0.9.1",
-    "mocha": "^2.0.1"
-  }
+    "eslint": "^1.1.0",
+    "mocha": "^2.2.5"
+  },
+  "directories": {
+    "test": "test"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LOKE/loke-config.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LOKE/loke-config/issues"
+  },
+  "homepage": "https://github.com/LOKE/loke-config#readme"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,13 +2,11 @@ var LokeConfig = require('../lib').LokeConfig;
 var assert = require('assert');
 var path = require('path');
 
-var confpath = path.join(__dirname, 'testconf.yml');
-
 describe('LokeConfig', function () {
   var conf;
   var paths = [
-    __dirname + '/config/defaults.yml',
-    __dirname + '/config/config.yml'
+    path.join(__dirname, '/config/defaults.yml'),
+    path.join(__dirname, '/config/config.yml')
   ];
 
   beforeEach(function () {
@@ -34,7 +32,7 @@ describe('LokeConfig', function () {
     it('should override values higher level configs', function () {
       assert.strictEqual(conf.get('parent.boolean'), false);
     });
-    
+
   });
 
 
@@ -43,8 +41,8 @@ describe('LokeConfig', function () {
     it('should not allow properties that dont exist in the defaults model', function (done) {
       try {
         var paths = [
-          __dirname + '/config/defaults.yml',
-          __dirname + '/config/fail.yml'
+          path.join(__dirname, '/config/defaults.yml'),
+          path.join(__dirname, '/config/fail.yml')
         ];
         conf = new LokeConfig('demo', paths);
         done(new Error('Should have thrown error'));
@@ -52,7 +50,7 @@ describe('LokeConfig', function () {
         done();
       }
     });
-    
+
   });
 
 });


### PR DESCRIPTION
Sometimes `require.main` may not be at the root of the app. It was in ./bin/ and I'm unsure what would happen when running within mocha.
