### PR TITLE
Don't preventExtensions on arrays

### DIFF
--- a/lib/loke-config.js
+++ b/lib/loke-config.js
@@ -35,11 +35,11 @@ function LokeConfig(appName, options) {
   var settings, self = this;
   var argv = minimist(process.argv.slice(2));
   var appPath = options.appPath || dirname(require.main.filename);
-  var paths = options.paths || [];
+  var paths = options.paths;
   var defaultsPath = options.defaultPath || resolve(appPath, './config/defaults.yml');
   var configPath = argv.config;
 
-  if (!configPath) {
+  if (!configPath && !paths) {
     paths = self._getDefaultPaths(appName, appPath);
   }
 


### PR DESCRIPTION
This was causing issues:

defaults:

```
{values: []}
```

config:

```
values: [1]
```

Also fixed the `paths` argument being ignored.
